### PR TITLE
Use `next` for early return from `inside` block

### DIFF
--- a/lib/trokko/cli.rb
+++ b/lib/trokko/cli.rb
@@ -84,7 +84,7 @@ module Trokko
           raise Thor::InvocationError, '[ERROR] Failed to generate rails application'
         end
 
-        return if File.stat('config').uid == uid
+        next if File.stat('config').uid == uid
 
         unless system(
           "docker compose run --no-deps --entrypoint '' --rm app" \
@@ -106,7 +106,7 @@ module Trokko
 
       say 'Building docker image...', :yellow
       inside name do
-        return if system('docker compose build')
+        next if system('docker compose build')
 
         say 'Stop executing task', :red
         raise Thor::InvocationError, '[ERROR] Failed to build docker image'


### PR DESCRIPTION
In Ruby, calling `return` in a block also exits the method.
Then, when you move a directory with Thor's `inside` method,
the directory you pushed to `@destination_stack` will remain
without being `pop`ed.

See-also: https://github.com/rails/thor/blob/937c4431b2dbbdf233184cf68451eb3f0a808cf2/lib/thor/actions.rb#L193